### PR TITLE
File order matters to the linker. GCC demands this order.

### DIFF
--- a/bindings/node.js/binding.dist.gyp
+++ b/bindings/node.js/binding.dist.gyp
@@ -16,8 +16,8 @@
         "<!@(node -p \"require('node-addon-api').include\")"
       ],
       "libraries": [
-        "<(module_root_dir)/libblst.a",
-        "<(module_root_dir)/c_kzg_4844.o"
+        "<(module_root_dir)/c_kzg_4844.o",
+        "<(module_root_dir)/libblst.a"
       ],
       "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
       "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"],

--- a/bindings/node.js/binding.gyp
+++ b/bindings/node.js/binding.gyp
@@ -16,8 +16,8 @@
         "<!@(node -p \"require('node-addon-api').include\")"
       ],
       "libraries": [
-        "<(module_root_dir)/c_kzg_4844.o",
-        "<(module_root_dir)/../../lib/libblst.a"
+        "<(module_root_dir)/../../lib/libblst.a",
+        "<(module_root_dir)/c_kzg_4844.o"
       ],
       "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
       "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"]

--- a/bindings/node.js/package.json
+++ b/bindings/node.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-kzg",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "NodeJS bindings for C-KZG",
   "author": "Dan Coffman",
   "license": "MIT",


### PR DESCRIPTION
Apparently, `c_kzg_4844.o` has to precede `libblst.a` in the arguments list to ld (or gcc invoking ld) on Linux, otherwise `libblst.a` doesn't get linked to `kzg.node` correctly.