### PR TITLE
Node bindings Linux test harness

### DIFF
--- a/bindings/node.js/.npmignore
+++ b/bindings/node.js/.npmignore
@@ -15,3 +15,4 @@ rollup.config.js
 tsconfig.json
 babel.config.js
 *.bak
+Dockerfile

--- a/bindings/node.js/.npmignore
+++ b/bindings/node.js/.npmignore
@@ -16,3 +16,5 @@ tsconfig.json
 babel.config.js
 *.bak
 Dockerfile
+binding.dist.gyp
+Makefile

--- a/bindings/node.js/Dockerfile
+++ b/bindings/node.js/Dockerfile
@@ -1,0 +1,20 @@
+# Exists as a test harness for building and running tests in Linux
+
+FROM node:16
+
+COPY ./dist/ /app/dist/
+COPY test.ts /app
+COPY trusted_setup.txt /app
+COPY kzg.ts /app
+COPY kzg.cxx /app
+COPY package.json /app
+COPY tsconfig.json /app
+COPY babel.config.js /app
+COPY jest.config.js /app
+COPY binding.dist.gyp /app/binding.gyp
+
+WORKDIR /app
+
+RUN yarn install
+
+CMD ["yarn", "jest"]

--- a/bindings/node.js/Makefile
+++ b/bindings/node.js/Makefile
@@ -29,3 +29,10 @@ publish: bundle
 	mv binding.gyp binding.gyp.bak
 	cp binding.dist.gyp binding.gyp
 	npm publish && mv binding.gyp.bak binding.gyp || mv binding.gyp.bak binding.gyp
+
+
+linux-test: bundle
+	cp ../../src/trusted_setup.txt .
+	docker build -t "linux-test" .
+	rm trusted_setup.txt
+	docker logs --follow `docker run -d linux-test`

--- a/bindings/node.js/binding.dist.gyp
+++ b/bindings/node.js/binding.dist.gyp
@@ -16,8 +16,8 @@
         "<!@(node -p \"require('node-addon-api').include\")"
       ],
       "libraries": [
-        "<(module_root_dir)/libblst.a",
-        "<(module_root_dir)/c_kzg_4844.o"
+        "<(module_root_dir)/c_kzg_4844.o",
+        "<(module_root_dir)/libblst.a"
       ],
       "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
       "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"],

--- a/bindings/node.js/binding.dist.gyp
+++ b/bindings/node.js/binding.dist.gyp
@@ -53,6 +53,10 @@
         {
           "files": ["./build/Release/kzg.node"],
           "destination": "./dist"
+        },
+        {
+          "files": ["./build/Release/kzg.node"],
+          "destination": "./"
         }
       ]
     }

--- a/bindings/node.js/binding.gyp
+++ b/bindings/node.js/binding.gyp
@@ -16,8 +16,8 @@
         "<!@(node -p \"require('node-addon-api').include\")"
       ],
       "libraries": [
-        "<(module_root_dir)/c_kzg_4844.o",
-        "<(module_root_dir)/../../lib/libblst.a"
+        "<(module_root_dir)/../../lib/libblst.a",
+        "<(module_root_dir)/c_kzg_4844.o"
       ],
       "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
       "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"]

--- a/bindings/node.js/kzg.cxx
+++ b/bindings/node.js/kzg.cxx
@@ -155,6 +155,7 @@ Napi::Value ComputeAggregateKzgProof(const Napi::CallbackInfo& info) {
   auto kzg_settings = info[1].As<Napi::External<KZGSettings>>().Data();
 
   auto blobs_count = blobs_param.Length();
+
   auto blobs = (Blob*)calloc(blobs_count, sizeof(Blob));
 
   for (uint32_t blob_index = 0; blob_index < blobs_count; blob_index++) {

--- a/bindings/node.js/package.json
+++ b/bindings/node.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-kzg",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "NodeJS bindings for C-KZG",
   "author": "Dan Coffman",
   "license": "MIT",

--- a/bindings/node.js/package.json
+++ b/bindings/node.js/package.json
@@ -12,12 +12,14 @@
     "@rollup/plugin-typescript": "^9.0.2",
     "@types/jest": "^29.2.1",
     "jest": "^29.2.2",
-    "node-addon-api": "^5.0.0",
     "node-gyp": "^9.3.0",
     "prettier": "2.7.1",
     "rollup": "^3.2.5",
     "ts-jest": "^29.0.3",
     "tslib": "^2.4.1",
     "typescript": "^4.8.4"
+  },
+  "dependencies": {
+    "node-addon-api": "^5.0.0"
   }
 }

--- a/bindings/node.js/package.json
+++ b/bindings/node.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-kzg",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "NodeJS bindings for C-KZG",
   "author": "Dan Coffman",
   "license": "MIT",

--- a/bindings/node.js/test.ts
+++ b/bindings/node.js/test.ts
@@ -37,17 +37,17 @@ describe("C-KZG", () => {
     expect(verifyAggregateKzgProof(blobs, commitments, proof)).toBe(true);
   });
 
-  it("computes the aggregate proof when blobs is an empty array", () => {
-    const proof = computeAggregateKzgProof([]);
-
-    // Is this actually what the aggregate proof for an empty array should be?
-    expect(proof.toString()).toEqual(
-      [
-        192, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0,
-      ].toString(),
+  it("throws an error when blobs is an empty array", () => {
+    expect(() => computeAggregateKzgProof([])).toThrowError(
+      "Failed to compute proof",
     );
+  });
+
+  it("computes the aggregate proof when for a single blob", () => {
+    let blobs = new Array(1).fill(0).map(generateRandomBlob);
+    let commitments = blobs.map(blobToKzgCommitment);
+    let proof = computeAggregateKzgProof(blobs);
+    expect(verifyAggregateKzgProof(blobs, commitments, proof)).toBe(true);
   });
 
   it("fails when given incorrect commitments", () => {

--- a/bindings/node.js/test.ts
+++ b/bindings/node.js/test.ts
@@ -1,4 +1,6 @@
 import { randomBytes } from "crypto";
+import { existsSync } from "fs";
+
 import {
   loadTrustedSetup,
   freeTrustedSetup,
@@ -9,7 +11,12 @@ import {
   FIELD_ELEMENTS_PER_BLOB,
 } from "./kzg";
 
-const SETUP_FILE_PATH = "../../src/trusted_setup.txt";
+const setupFileName = "trusted_setup.txt";
+
+const SETUP_FILE_PATH = existsSync(setupFileName)
+  ? setupFileName
+  : `../../src/${setupFileName}`;
+
 const BLOB_BYTE_COUNT = FIELD_ELEMENTS_PER_BLOB * BYTES_PER_FIELD_ELEMENT;
 
 const generateRandomBlob = () => new Uint8Array(randomBytes(BLOB_BYTE_COUNT));
@@ -23,11 +30,24 @@ describe("C-KZG", () => {
     freeTrustedSetup();
   });
 
-  it("computes the correct commitments and aggregate proofs from blobs", () => {
-    const blobs = new Array(2).fill(0).map(generateRandomBlob);
-    const commitments = blobs.map(blobToKzgCommitment);
-    const proof = computeAggregateKzgProof(blobs);
+  it("computes the correct commitments and aggregate proof from blobs", () => {
+    let blobs = new Array(2).fill(0).map(generateRandomBlob);
+    let commitments = blobs.map(blobToKzgCommitment);
+    let proof = computeAggregateKzgProof(blobs);
     expect(verifyAggregateKzgProof(blobs, commitments, proof)).toBe(true);
+  });
+
+  it("computes the aggregate proof when blobs is an empty array", () => {
+    const proof = computeAggregateKzgProof([]);
+
+    // Is this actually what the aggregate proof for an empty array should be?
+    expect(proof.toString()).toEqual(
+      [
+        192, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0,
+      ].toString(),
+    );
   });
 
   it("fails when given incorrect commitments", () => {


### PR DESCRIPTION
This PR adds the ability to compile the code and bindings in a Linux docker container and run the TS unit tests against that.

From bindings/node.js, run `make linux-test`