### PR TITLE
Update test for computeAggregateKzgProof empty blobs array special case

### DIFF
--- a/bindings/node.js/binding.dist.gyp
+++ b/bindings/node.js/binding.dist.gyp
@@ -4,31 +4,11 @@
       "target_name": "kzg",
       "cflags!": ["-fno-exceptions"],
       "cflags_cc!": ["-fno-exceptions"],
-      "conditions": [
-        [
-          "OS=='win'",
-          {
-            "defines": ["_HAS_EXCEPTIONS=1"],
-            "msvs_settings": {
-              "VCCLCompilerTool": {
-                "ExceptionHandling": 1
-              }
-            }
-          }
-        ],
-        [
-          "OS=='mac'",
-          {
-            "cflags+": ["-fvisibility=hidden"],
-            "xcode_settings": {
-              "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
-              "CLANG_CXX_LIBRARY": "libc++",
-              "MACOSX_DEPLOYMENT_TARGET": "10.7",
-              "GCC_SYMBOLS_PRIVATE_EXTERN": "YES"
-            }
-          }
-        ]
-      ],
+      "xcode_settings": {
+        "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+        "CLANG_CXX_LIBRARY": "libc++",
+        "MACOSX_DEPLOYMENT_TARGET": "13.0"
+      },
       "sources": ["kzg.cxx"],
       "include_dirs": [
         "<(module_root_dir)/dist/deps/blst/bindings",

--- a/bindings/node.js/binding.dist.gyp
+++ b/bindings/node.js/binding.dist.gyp
@@ -4,11 +4,31 @@
       "target_name": "kzg",
       "cflags!": ["-fno-exceptions"],
       "cflags_cc!": ["-fno-exceptions"],
-      "xcode_settings": {
-        "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
-        "CLANG_CXX_LIBRARY": "libc++",
-        "MACOSX_DEPLOYMENT_TARGET": "13.0"
-      },
+      "conditions": [
+        [
+          "OS=='win'",
+          {
+            "defines": ["_HAS_EXCEPTIONS=1"],
+            "msvs_settings": {
+              "VCCLCompilerTool": {
+                "ExceptionHandling": 1
+              }
+            }
+          }
+        ],
+        [
+          "OS=='mac'",
+          {
+            "cflags+": ["-fvisibility=hidden"],
+            "xcode_settings": {
+              "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+              "CLANG_CXX_LIBRARY": "libc++",
+              "MACOSX_DEPLOYMENT_TARGET": "10.7",
+              "GCC_SYMBOLS_PRIVATE_EXTERN": "YES"
+            }
+          }
+        ]
+      ],
       "sources": ["kzg.cxx"],
       "include_dirs": [
         "<(module_root_dir)/dist/deps/blst/bindings",
@@ -20,7 +40,6 @@
         "<(module_root_dir)/libblst.a"
       ],
       "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
-      "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"],
       "actions": [
         {
           "action_name": "build_blst",

--- a/bindings/node.js/binding.dist.gyp
+++ b/bindings/node.js/binding.dist.gyp
@@ -5,10 +5,10 @@
       "cflags!": ["-fno-exceptions"],
       "cflags_cc!": ["-fno-exceptions"],
       "xcode_settings": {
-        "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
         "CLANG_CXX_LIBRARY": "libc++",
         "MACOSX_DEPLOYMENT_TARGET": "13.0"
       },
+      "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"],
       "sources": ["kzg.cxx"],
       "include_dirs": [
         "<(module_root_dir)/dist/deps/blst/bindings",

--- a/bindings/node.js/binding.gyp
+++ b/bindings/node.js/binding.gyp
@@ -4,11 +4,31 @@
       "target_name": "kzg",
       "cflags!": ["-fno-exceptions"],
       "cflags_cc!": ["-fno-exceptions"],
-      "xcode_settings": {
-        "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
-        "CLANG_CXX_LIBRARY": "libc++",
-        "MACOSX_DEPLOYMENT_TARGET": "13.0"
-      },
+      "conditions": [
+        [
+          "OS=='win'",
+          {
+            "defines": ["_HAS_EXCEPTIONS=1"],
+            "msvs_settings": {
+              "VCCLCompilerTool": {
+                "ExceptionHandling": 1
+              }
+            }
+          }
+        ],
+        [
+          "OS=='mac'",
+          {
+            "cflags+": ["-fvisibility=hidden"],
+            "xcode_settings": {
+              "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+              "CLANG_CXX_LIBRARY": "libc++",
+              "MACOSX_DEPLOYMENT_TARGET": "10.7",
+              "GCC_SYMBOLS_PRIVATE_EXTERN": "YES"
+            }
+          }
+        ]
+      ],
       "sources": ["kzg.cxx"],
       "include_dirs": [
         "../../inc",
@@ -19,8 +39,7 @@
         "<(module_root_dir)/c_kzg_4844.o",
         "<(module_root_dir)/../../lib/libblst.a"
       ],
-      "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
-      "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"]
+      "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"]
     },
     {
       "target_name": "action_after_build",

--- a/bindings/node.js/binding.gyp
+++ b/bindings/node.js/binding.gyp
@@ -4,31 +4,11 @@
       "target_name": "kzg",
       "cflags!": ["-fno-exceptions"],
       "cflags_cc!": ["-fno-exceptions"],
-      "conditions": [
-        [
-          "OS=='win'",
-          {
-            "defines": ["_HAS_EXCEPTIONS=1"],
-            "msvs_settings": {
-              "VCCLCompilerTool": {
-                "ExceptionHandling": 1
-              }
-            }
-          }
-        ],
-        [
-          "OS=='mac'",
-          {
-            "cflags+": ["-fvisibility=hidden"],
-            "xcode_settings": {
-              "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
-              "CLANG_CXX_LIBRARY": "libc++",
-              "MACOSX_DEPLOYMENT_TARGET": "10.7",
-              "GCC_SYMBOLS_PRIVATE_EXTERN": "YES"
-            }
-          }
-        ]
-      ],
+      "xcode_settings": {
+        "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+        "CLANG_CXX_LIBRARY": "libc++",
+        "MACOSX_DEPLOYMENT_TARGET": "13.0"
+      },
       "sources": ["kzg.cxx"],
       "include_dirs": [
         "../../inc",

--- a/bindings/node.js/binding.gyp
+++ b/bindings/node.js/binding.gyp
@@ -5,10 +5,10 @@
       "cflags!": ["-fno-exceptions"],
       "cflags_cc!": ["-fno-exceptions"],
       "xcode_settings": {
-        "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
         "CLANG_CXX_LIBRARY": "libc++",
         "MACOSX_DEPLOYMENT_TARGET": "13.0"
       },
+      "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"],
       "sources": ["kzg.cxx"],
       "include_dirs": [
         "../../inc",

--- a/bindings/node.js/kzg.cxx
+++ b/bindings/node.js/kzg.cxx
@@ -8,28 +8,24 @@
 #include "c_kzg_4844.h"
 #include "blst.h"
 
-Napi::Value throw_invalid_arguments_count(
+void throw_invalid_arguments_count(
   const uint expected,
   const uint actual,
   const Napi::Env env
 ) {
-  Napi::RangeError::New(
+  throw Napi::RangeError::New(
     env,
     "Wrong number of arguments. Expected: "
     + std::to_string(expected)
     + ", received " + std::to_string(actual)
-  ).ThrowAsJavaScriptException();
-
-  return env.Null();
+  );
 }
 
-Napi::Value throw_invalid_argument_type(const Napi::Env env, std::string name, std::string expectedType) {
-  Napi::TypeError::New(
+void throw_invalid_argument_type(const Napi::Env env, std::string name, std::string expectedType) {
+  throw Napi::TypeError::New(
     env,
-    "Invalid parameter type: " + name + ". Expected " + expectedType
-  ).ThrowAsJavaScriptException();
-
-  return env.Null();
+    "Invalid argument type: " + name + ". Expected " + expectedType
+  );
 }
 
 Napi::TypedArrayOf<uint8_t> napi_typed_array_from_bytes(uint8_t* array, size_t length, Napi::Env env) {
@@ -66,11 +62,11 @@ Napi::Value LoadTrustedSetup(const Napi::CallbackInfo& info) {
   size_t argument_count = info.Length();
   size_t expected_argument_count = 1;
   if (argument_count != expected_argument_count) {
-    return throw_invalid_arguments_count(expected_argument_count, argument_count, env);
+    throw_invalid_arguments_count(expected_argument_count, argument_count, env);
   }
 
   if (!info[0].IsString()) {
-    return throw_invalid_argument_type(env, "filePath", "string");
+    throw_invalid_argument_type(env, "filePath", "string");
   }
 
   const std::string file_path = info[0].ToString().Utf8Value();
@@ -106,7 +102,7 @@ Napi::Value FreeTrustedSetup(const Napi::CallbackInfo& info) {
   size_t argument_count = info.Length();
   size_t expected_argument_count = 1;
   if (argument_count != expected_argument_count) {
-    return throw_invalid_arguments_count(expected_argument_count, argument_count, env);
+    throw_invalid_arguments_count(expected_argument_count, argument_count, env);
   }
 
   auto kzg_settings = info[0].As<Napi::External<KZGSettings>>().Data();
@@ -122,12 +118,12 @@ Napi::Value BlobToKzgCommitment(const Napi::CallbackInfo& info) {
   size_t argument_count = info.Length();
   size_t expected_argument_count = 2;
   if (argument_count != expected_argument_count) {
-    return throw_invalid_arguments_count(expected_argument_count, argument_count, env);
+    throw_invalid_arguments_count(expected_argument_count, argument_count, env);
   }
 
   auto blob_param = info[0].As<Napi::TypedArray>();
-  if (blob_param.TypedArrayType() != napi_uint8_array) {
-     return throw_invalid_argument_type(env, "blob", "UInt8Array");
+  if (!blob_param.IsTypedArray() || blob_param.TypedArrayType() != napi_uint8_array) {
+    throw_invalid_argument_type(env, "blob", "UInt8Array");
   }
   auto blob = blob_param.As<Napi::Uint8Array>().Data();
 
@@ -148,7 +144,7 @@ Napi::Value ComputeAggregateKzgProof(const Napi::CallbackInfo& info) {
   size_t argument_count = info.Length();
   size_t expected_argument_count = 2;
   if (argument_count != expected_argument_count) {
-    return throw_invalid_arguments_count(expected_argument_count, argument_count, env);
+    throw_invalid_arguments_count(expected_argument_count, argument_count, env);
   }
 
   auto blobs_param = info[0].As<Napi::Array>();
@@ -191,7 +187,7 @@ Napi::Value VerifyAggregateKzgProof(const Napi::CallbackInfo& info) {
   size_t argument_count = info.Length();
   size_t expected_argument_count = 4;
   if (argument_count != expected_argument_count) {
-    return throw_invalid_arguments_count(expected_argument_count, argument_count, env);
+    throw_invalid_arguments_count(expected_argument_count, argument_count, env);
   }
 
   auto blobs_param = info[0].As<Napi::Array>();
@@ -277,30 +273,30 @@ Napi::Value VerifyKzgProof(const Napi::CallbackInfo& info) {
   size_t argument_count = info.Length();
   size_t expected_argument_count = 5;
   if (argument_count != expected_argument_count) {
-    return throw_invalid_arguments_count(expected_argument_count, argument_count, env);
+    throw_invalid_arguments_count(expected_argument_count, argument_count, env);
   }
 
   auto c_param = info[0].As<Napi::TypedArray>();
   if (c_param.TypedArrayType() != napi_uint8_array) {
-    return throw_invalid_argument_type(env, "polynomialKzg", "UInt8Array");
+    throw_invalid_argument_type(env, "polynomialKzg", "UInt8Array");
   }
   auto polynomial_kzg = c_param.As<Napi::Uint8Array>().Data();
 
   auto z_param = info[1].As<Napi::TypedArray>();
   if (z_param.TypedArrayType() != napi_uint8_array) {
-     return throw_invalid_argument_type(env, "z", "UInt8Array");
+     throw_invalid_argument_type(env, "z", "UInt8Array");
   }
   auto z = z_param.As<Napi::Uint8Array>().Data();
 
   auto y_param = info[2].As<Napi::TypedArray>();
   if (y_param.TypedArrayType() != napi_uint8_array) {
-    return throw_invalid_argument_type(env, "y", "UInt8Array");
+    throw_invalid_argument_type(env, "y", "UInt8Array");
   }
   auto y = y_param.As<Napi::Uint8Array>().Data();
 
   auto proof_param = info[3].As<Napi::TypedArray>();
   if (proof_param.TypedArrayType() != napi_uint8_array) {
-     return throw_invalid_argument_type(env, "kzgProof", "UInt8Array");
+     throw_invalid_argument_type(env, "kzgProof", "UInt8Array");
   }
   auto kzg_proof = proof_param.As<Napi::Uint8Array>().Data();
 

--- a/bindings/node.js/kzg.cxx
+++ b/bindings/node.js/kzg.cxx
@@ -8,24 +8,28 @@
 #include "c_kzg_4844.h"
 #include "blst.h"
 
-void throw_invalid_arguments_count(
+Napi::Value throw_invalid_arguments_count(
   const uint expected,
   const uint actual,
   const Napi::Env env
 ) {
-  throw Napi::RangeError::New(
+  Napi::RangeError::New(
     env,
     "Wrong number of arguments. Expected: "
     + std::to_string(expected)
     + ", received " + std::to_string(actual)
-  );
+  ).ThrowAsJavaScriptException();
+
+  return env.Null();
 }
 
-void throw_invalid_argument_type(const Napi::Env env, std::string name, std::string expectedType) {
-  throw Napi::TypeError::New(
+Napi::Value throw_invalid_argument_type(const Napi::Env env, std::string name, std::string expectedType) {
+  Napi::TypeError::New(
     env,
     "Invalid argument type: " + name + ". Expected " + expectedType
-  );
+  ).ThrowAsJavaScriptException();
+
+  return env.Null();
 }
 
 Napi::TypedArrayOf<uint8_t> napi_typed_array_from_bytes(uint8_t* array, size_t length, Napi::Env env) {
@@ -62,11 +66,11 @@ Napi::Value LoadTrustedSetup(const Napi::CallbackInfo& info) {
   size_t argument_count = info.Length();
   size_t expected_argument_count = 1;
   if (argument_count != expected_argument_count) {
-    throw_invalid_arguments_count(expected_argument_count, argument_count, env);
+    return throw_invalid_arguments_count(expected_argument_count, argument_count, env);
   }
 
   if (!info[0].IsString()) {
-    throw_invalid_argument_type(env, "filePath", "string");
+    return throw_invalid_argument_type(env, "filePath", "string");
   }
 
   const std::string file_path = info[0].ToString().Utf8Value();
@@ -102,7 +106,7 @@ Napi::Value FreeTrustedSetup(const Napi::CallbackInfo& info) {
   size_t argument_count = info.Length();
   size_t expected_argument_count = 1;
   if (argument_count != expected_argument_count) {
-    throw_invalid_arguments_count(expected_argument_count, argument_count, env);
+    return throw_invalid_arguments_count(expected_argument_count, argument_count, env);
   }
 
   auto kzg_settings = info[0].As<Napi::External<KZGSettings>>().Data();
@@ -118,12 +122,12 @@ Napi::Value BlobToKzgCommitment(const Napi::CallbackInfo& info) {
   size_t argument_count = info.Length();
   size_t expected_argument_count = 2;
   if (argument_count != expected_argument_count) {
-    throw_invalid_arguments_count(expected_argument_count, argument_count, env);
+    return throw_invalid_arguments_count(expected_argument_count, argument_count, env);
   }
 
   auto blob_param = info[0].As<Napi::TypedArray>();
   if (!blob_param.IsTypedArray() || blob_param.TypedArrayType() != napi_uint8_array) {
-    throw_invalid_argument_type(env, "blob", "UInt8Array");
+     return throw_invalid_argument_type(env, "blob", "UInt8Array");
   }
   auto blob = blob_param.As<Napi::Uint8Array>().Data();
 
@@ -144,7 +148,7 @@ Napi::Value ComputeAggregateKzgProof(const Napi::CallbackInfo& info) {
   size_t argument_count = info.Length();
   size_t expected_argument_count = 2;
   if (argument_count != expected_argument_count) {
-    throw_invalid_arguments_count(expected_argument_count, argument_count, env);
+    return throw_invalid_arguments_count(expected_argument_count, argument_count, env);
   }
 
   auto blobs_param = info[0].As<Napi::Array>();
@@ -187,7 +191,7 @@ Napi::Value VerifyAggregateKzgProof(const Napi::CallbackInfo& info) {
   size_t argument_count = info.Length();
   size_t expected_argument_count = 4;
   if (argument_count != expected_argument_count) {
-    throw_invalid_arguments_count(expected_argument_count, argument_count, env);
+    return throw_invalid_arguments_count(expected_argument_count, argument_count, env);
   }
 
   auto blobs_param = info[0].As<Napi::Array>();
@@ -273,30 +277,30 @@ Napi::Value VerifyKzgProof(const Napi::CallbackInfo& info) {
   size_t argument_count = info.Length();
   size_t expected_argument_count = 5;
   if (argument_count != expected_argument_count) {
-    throw_invalid_arguments_count(expected_argument_count, argument_count, env);
+    return throw_invalid_arguments_count(expected_argument_count, argument_count, env);
   }
 
   auto c_param = info[0].As<Napi::TypedArray>();
   if (c_param.TypedArrayType() != napi_uint8_array) {
-    throw_invalid_argument_type(env, "polynomialKzg", "UInt8Array");
+    return throw_invalid_argument_type(env, "polynomialKzg", "UInt8Array");
   }
   auto polynomial_kzg = c_param.As<Napi::Uint8Array>().Data();
 
   auto z_param = info[1].As<Napi::TypedArray>();
   if (z_param.TypedArrayType() != napi_uint8_array) {
-     throw_invalid_argument_type(env, "z", "UInt8Array");
+     return throw_invalid_argument_type(env, "z", "UInt8Array");
   }
   auto z = z_param.As<Napi::Uint8Array>().Data();
 
   auto y_param = info[2].As<Napi::TypedArray>();
   if (y_param.TypedArrayType() != napi_uint8_array) {
-    throw_invalid_argument_type(env, "y", "UInt8Array");
+    return throw_invalid_argument_type(env, "y", "UInt8Array");
   }
   auto y = y_param.As<Napi::Uint8Array>().Data();
 
   auto proof_param = info[3].As<Napi::TypedArray>();
   if (proof_param.TypedArrayType() != napi_uint8_array) {
-     throw_invalid_argument_type(env, "kzgProof", "UInt8Array");
+     return throw_invalid_argument_type(env, "kzgProof", "UInt8Array");
   }
   auto kzg_proof = proof_param.As<Napi::Uint8Array>().Data();
 

--- a/bindings/node.js/package.json
+++ b/bindings/node.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-kzg",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "NodeJS bindings for C-KZG",
   "author": "Dan Coffman",
   "license": "MIT",

--- a/bindings/node.js/package.json
+++ b/bindings/node.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-kzg",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "NodeJS bindings for C-KZG",
   "author": "Dan Coffman",
   "license": "MIT",

--- a/bindings/node.js/package.json
+++ b/bindings/node.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-kzg",
-  "version": "0.0.9",
+  "version": "1.0.0",
   "description": "NodeJS bindings for C-KZG",
   "author": "Dan Coffman",
   "license": "MIT",

--- a/bindings/node.js/package.json
+++ b/bindings/node.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-kzg",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "NodeJS bindings for C-KZG",
   "author": "Dan Coffman",
   "license": "MIT",

--- a/bindings/node.js/test.ts
+++ b/bindings/node.js/test.ts
@@ -37,7 +37,7 @@ describe("C-KZG", () => {
     expect(verifyAggregateKzgProof(blobs, commitments, proof)).toBe(true);
   });
 
-  it("throws an error when blobs is an empty array", () => {
+  it("returns the identity (aka zero, aka neutral) element when blobs is an empty array", () => {
     expect(computeAggregateKzgProof([]).toString()).toEqual(
       [
         192, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/bindings/node.js/test.ts
+++ b/bindings/node.js/test.ts
@@ -38,8 +38,12 @@ describe("C-KZG", () => {
   });
 
   it("throws an error when blobs is an empty array", () => {
-    expect(() => computeAggregateKzgProof([])).toThrowError(
-      "Failed to compute proof",
+    expect(computeAggregateKzgProof([]).toString()).toEqual(
+      [
+        192, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0,
+      ].toString(),
     );
   });
 

--- a/bindings/node.js/test.ts
+++ b/bindings/node.js/test.ts
@@ -63,4 +63,13 @@ describe("C-KZG", () => {
       verifyAggregateKzgProof(blobs, commitments, proof),
     ).toThrowError("Invalid commitment data");
   });
+
+  describe("computing commitment from blobs", () => {
+    it("throws as expected when given an argument of invalid type", () => {
+      // @ts-expect-error
+      expect(() => blobToKzgCommitment("wrong type")).toThrowError(
+        "Invalid argument type: blob. Expected UInt8Array",
+      );
+    });
+  });
 });


### PR DESCRIPTION
https://github.com/dankrad/c-kzg/commit/084fd2209ef19d7c415b40cca402d4d982e5470e changed the return for `computeAggregateKzgProof([])`

This PR updates the NodeJS bindings unit test to expect that.

Also fixes a case where the bindings could crash the NodeJS process, and covers that case with a test.