### PR TITLE
Correct type definitions

### DIFF
--- a/bindings/node.js/kzg.ts
+++ b/bindings/node.js/kzg.ts
@@ -57,7 +57,7 @@ function requireSetupHandle(): SetupHandle {
   return setupHandle;
 }
 
-export function loadTrustedSetup(filePath: string): void {
+export function loadTrustedSetup(filePath: string): SetupHandle {
   if (setupHandle) {
     throw new Error(
       "Call freeTrustedSetup before loading a new trusted setup.",
@@ -71,11 +71,11 @@ export function freeTrustedSetup(): void {
   setupHandle = undefined;
 }
 
-export function blobToKzgCommitment(blob: Blob): KZGCommitment {
+export function blobToKzgCommitment(blob: Blob, setupHandle: SetupHandle): KZGCommitment {
   return kzg.blobToKzgCommitment(blob, requireSetupHandle());
 }
 
-export function computeAggregateKzgProof(blobs: Blob[]): KZGProof {
+export function computeAggregateKzgProof(blobs: Blob[], setupHandle: SetupHandle): KZGProof {
   return kzg.computeAggregateKzgProof(blobs, requireSetupHandle());
 }
 
@@ -83,6 +83,7 @@ export function verifyAggregateKzgProof(
   blobs: Blob[],
   expectedKzgCommitments: KZGCommitment[],
   kzgAggregatedProof: KZGProof,
+  setupHandle: SetupHandle
 ): boolean {
   return kzg.verifyAggregateKzgProof(
     blobs,


### PR DESCRIPTION
I'm not 100% these definitions are correct but when I followed the existing types as declared in the node.js bindings, I got errors saying I was missing a parameter.  When I added the `SetupHandle` returned from `loadTrustedSetup` to each function call, it seemed to address the issue (and this would match with the readme for the Node.js bindings).